### PR TITLE
Setup GitHub Pages with Jekyll and just-the-docs theme

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,63 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: |
+          gem install jekyll bundler just-the-docs jekyll-remote-theme jekyll-seo-tag
+          jekyll build
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    # Only deploy if it's a push to master, PRs should just run the build step to test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,6 +36,8 @@ jobs:
           ruby-version: '3.1' # Not needed with a .ruby-version file
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ reports/
 # Python Files
 Algorithms/Neeraj/venv/*
 /venv/
+_site/

--- a/Algorithms/README.md
+++ b/Algorithms/README.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "Algorithms"
+has_children: true
+nav_order: 20
+---
+
+# Algorithms

--- a/Algorithms/binarysearch/README.md
+++ b/Algorithms/binarysearch/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Binary Search"
+parent: "Algorithms"
+---
+
 # Binary Search
 
 Binary search is a highly efficient searching algorithm that works on **sorted** arrays. It repeatedly divides the search interval in half. If the value of the search key is less than the item in the middle of the interval, it narrows the interval to the lower half. Otherwise, it narrows it to the upper half.

--- a/Algorithms/coursera/README.md
+++ b/Algorithms/coursera/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Algorithmic Toolbox"
+parent: "Algorithms"
+---
+
 # Algorithmic Toolbox
 
 ## Course assignments

--- a/Algorithms/dfs-bfs/README.md
+++ b/Algorithms/dfs-bfs/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "DFS (Depth-First Search) and BFS (Breadth-First Search)"
+parent: "Algorithms"
+---
+
 # DFS (Depth-First Search) and BFS (Breadth-First Search)
 
 DFS and BFS are two fundamental graph and tree traversal algorithms.
@@ -17,6 +23,7 @@ DFS explores as far as possible along each branch before backtracking. It can be
 This is the most common way to implement DFS for graph/grid problems.
 
 ```java
+{% raw %}
 class Solution {
     public void dfs(int r, int c, boolean[][] visited, char[][] grid) {
         int ROWS = grid.length;
@@ -36,6 +43,7 @@ class Solution {
         dfs(r, c - 1, visited, grid);
     }
 }
+{% endraw %}
 ```
 
 ---
@@ -53,6 +61,7 @@ BFS explores all of the neighbor nodes at the present depth prior to moving on t
 ### Template: BFS
 
 ```java
+{% raw %}
 import java.util.Queue;
 import java.util.LinkedList;
 
@@ -86,6 +95,7 @@ class Solution {
         }
     }
 }
+{% endraw %}
 ```
 
 **Example Problem for both:** [Number of Islands](https://leetcode.com/problems/number-of-islands/)

--- a/Algorithms/dynamic-problem/README.md
+++ b/Algorithms/dynamic-problem/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Dynamic Programming (DP)"
+parent: "Algorithms"
+---
+
 # Dynamic Programming (DP)
 
 Dynamic Programming is a method for solving a complex problem by breaking it down into a collection of simpler subproblems, solving each of those subproblems just once, and storing their solutions.

--- a/Algorithms/greedy-algorithum/README.md
+++ b/Algorithms/greedy-algorithum/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Greedy Algorithms"
+parent: "Algorithms"
+---
+
 # Greedy Algorithms
 
 A greedy algorithm is an algorithmic paradigm that builds up a solution piece by piece, always choosing the next piece that offers the most obvious and immediate benefit. It makes the locally optimal choice at each stage with the hope of finding a global optimum.

--- a/Algorithms/recursion-backtracking/README.md
+++ b/Algorithms/recursion-backtracking/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Recursion and Backtracking"
+parent: "Algorithms"
+---
+
 # Recursion and Backtracking
 
 ## Recursion

--- a/Algorithms/sliding-window/README.md
+++ b/Algorithms/sliding-window/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Sliding Window"
+parent: "Algorithms"
+---
+
 # Sliding Window
 
 The sliding window is a technique used to efficiently solve problems that involve a contiguous subarray or substring. A "window" of a certain size slides over the data, and we perform some computation on the elements within that window.

--- a/Algorithms/topologicalsort/README.md
+++ b/Algorithms/topologicalsort/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Topological Sort"
+parent: "Algorithms"
+---
+
 # Topological Sort
 
 Topological Sort is a linear ordering of vertices in a **Directed Acyclic Graph (DAG)**. For every directed edge from vertex `u` to vertex `v`, vertex `u` comes before vertex `v` in the ordering.

--- a/Algorithms/two-pointer/README.md
+++ b/Algorithms/two-pointer/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Two Pointers"
+parent: "Algorithms"
+---
+
 # Two Pointers
 
 The two-pointers technique is a common pattern used to solve problems involving sorted arrays or linked lists. It involves using two pointers to iterate through the data structure, often from opposite ends or at different speeds.

--- a/All_Topics_top_leetcode_by_frequency.md
+++ b/All_Topics_top_leetcode_by_frequency.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "All Topics Top Frequency"
+nav_order: 4
+---
+
 ## LeetCode [Explore](https://leetcode.com/explore/learn/)
 
 | **#** | **Title** | **Acceptance** | **Difficulty** |

--- a/EPI_Questions_List.md
+++ b/EPI_Questions_List.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "EPI Questions"
+nav_order: 5
+---
+
 ### Below are the list of EPI Questions along with the topics.
 
 |Topic                           |Question No|Question                                                        |Solution                                                                                                                                                                               |Page No.|

--- a/ImportantLinks.md
+++ b/ImportantLinks.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Important Links"
+nav_order: 7
+---
+
 # Hacking Software Engineering Interviews
 
 ## Recruiting Platforms with Technical Prescreen

--- a/LeetCode_FAQ.md
+++ b/LeetCode_FAQ.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "LeetCode FAQ"
+nav_order: 6
+---
+
 # LeetCode FAQ
 
 This document answers some frequently asked technical questions about the LeetCode platform, based on common user queries.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: "Home"
+nav_order: 1
+permalink: /
+---
+
 <p align="center">
   <img height="100" src="https://www.pcr-online.biz/wp-content/uploads/faang-own-logo-660x330.jpg" alt="FAANG Logo">
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Security"
+nav_order: 8
+---
+
 # Security Policy
 
 ## Supported Versions

--- a/Top_LeetCode_Questions_By_Company.md
+++ b/Top_LeetCode_Questions_By_Company.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Top LeetCode by Company"
+nav_order: 3
+---
+
 # Questions by Companies
 
 ## Google

--- a/Top_LeetCode_Questions_By_Topic.md
+++ b/Top_LeetCode_Questions_By_Topic.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Top LeetCode by Topic"
+nav_order: 2
+---
+
 # DataStructures & Algorithm Problems
 
 ## Array, Linked List, Stack, Heap, Graph, Tree, Queue

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,19 @@
+theme: "just-the-docs"
+remote_theme: just-the-docs/just-the-docs
+
+title: FAANG & Modern Tech Interviews
+description: A comprehensive collection of solutions, explanations, and resources for mastering coding interviews at top tech companies.
+url: "https://neerazz.github.io/FAANG"
+baseurl: "/FAANG"
+
+color_scheme: dark
+
+# Heading Anchor Links
+heading_anchors: true
+
+# Navigation Settings
+nav_sort: case_insensitive
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag

--- a/blind75/README.md
+++ b/blind75/README.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "Blind 75"
+has_children: true
+nav_order: 30
+---
+
+# Blind 75

--- a/dataStructures/LinkedList/README.md
+++ b/dataStructures/LinkedList/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Linked Lists"
+parent: "Data Structures"
+---
+
 # Linked Lists
 
 A linked list is a linear data structure where elements are not stored in contiguous memory locations. Instead, each element (node) contains a data field and a reference (or link) to the next node in the sequence.

--- a/dataStructures/README.md
+++ b/dataStructures/README.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "Data Structures"
+has_children: true
+nav_order: 10
+---
+
+# Data Structures

--- a/dataStructures/arrays/README.md
+++ b/dataStructures/arrays/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Arrays"
+parent: "Data Structures"
+---
+
 # Arrays
 
 An array is a data structure that stores a collection of elements of the same type in contiguous memory locations. Each element is identified by an index or a key.

--- a/dataStructures/binarytree/README.md
+++ b/dataStructures/binarytree/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Binary Trees"
+parent: "Data Structures"
+---
+
 # Binary Trees
 
 A binary tree is a tree data structure in which each node has at most two children, which are referred to as the *left child* and the *right child*.

--- a/dataStructures/coursera/README.md
+++ b/dataStructures/coursera/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Data Structures"
+parent: "Data Structures"
+---
+
 # Data Structures
 
 ## Course assignments

--- a/dataStructures/graph/README.md
+++ b/dataStructures/graph/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Graphs"
+parent: "Data Structures"
+---
+
 # Graphs
 
 A graph is a non-linear data structure consisting of **nodes** (or vertices) and **edges** that connect these nodes. Graphs are used to model relationships between objects.

--- a/dataStructures/hashtable/README.md
+++ b/dataStructures/hashtable/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Hash Tables (Hash Maps)"
+parent: "Data Structures"
+---
+
 # Hash Tables (Hash Maps)
 
 A hash table is a data structure that implements an associative array abstract data type, a structure that can map keys to values. A hash table uses a hash function to compute an index, also called a hash code, into an array of buckets or slots, from which the desired value can be found. In Java, `HashMap` and `HashSet` are the primary implementations.

--- a/dataStructures/heapAndSort/README.md
+++ b/dataStructures/heapAndSort/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Heaps and Sorting"
+parent: "Data Structures"
+---
+
 # Heaps and Sorting
 
 This section covers the heap data structure and various sorting algorithms.

--- a/dataStructures/queue/README.md
+++ b/dataStructures/queue/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Queues"
+parent: "Data Structures"
+---
+
 # Queues
 
 A queue is a linear data structure that follows the First-In, First-Out (FIFO) principle. This means the first element added to the queue will be the first one to be removed.
@@ -33,6 +39,7 @@ Queues are ideal for problems that involve:
 BFS is a common graph and tree traversal algorithm that uses a queue to explore nodes level by level.
 
 ```java
+{% raw %}
 import java.util.Queue;
 import java.util.LinkedList;
 import java.util.Set;
@@ -79,6 +86,7 @@ class Solution {
         }
     }
 }
+{% endraw %}
 ```
 
 **Example Problem:** [Number of Islands](https://leetcode.com/problems/number-of-islands/)

--- a/dataStructures/stack/README.md
+++ b/dataStructures/stack/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Stacks"
+parent: "Data Structures"
+---
+
 # Stacks
 
 A stack is a linear data structure that follows the Last-In, First-Out (LIFO) principle. This means the last element added to the stack will be the first one to be removed.

--- a/dataStructures/trie/README.md
+++ b/dataStructures/trie/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Trie (Prefix Tree)"
+parent: "Data Structures"
+---
+
 # Trie (Prefix Tree)
 
 A Trie, also known as a prefix tree, is a special tree-like data structure that is very efficient for retrieving a key in a dataset of strings. With a trie, you can search for a word or a prefix in a time complexity proportional to the length of the word, `O(L)`, where `L` is the length of the word.

--- a/dataStructures/unionfind/README.md
+++ b/dataStructures/unionfind/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "Union-Find (Disjoint Set Union)"
+parent: "Data Structures"
+---
+
 # Union-Find (Disjoint Set Union)
 
 The Union-Find data structure, also known as Disjoint Set Union (DSU), is used to keep track of a set of elements partitioned into a number of disjoint (non-overlapping) subsets. It provides two main operations:


### PR DESCRIPTION
This PR sets up a GitHub Pages documentation site using Jekyll and the `just-the-docs` theme to organize the extensive repository of Markdown files into a readable, navigable website.

It achieves the following:
1. Adds `_config.yml` to configure the Jekyll build with the `just-the-docs` theme.
2. Iterates through the repository to properly add YAML front-matter to all existing `.md` files (such as `title`, `parent`, and `has_children`) to build a clean navigation hierarchy.
3. Fixes Liquid build errors in Markdown files that included Java code with double curly braces (e.g., `int[][] directions = {{1, 0}}`) by wrapping those blocks in `{% raw %}` tags.
4. Adds `.github/workflows/gh-pages.yml` to run the build on pull requests, and deploy the site when pushed to `master`.
5. Updates `.gitignore` to prevent committing the local `_site` build folder.

---
*PR created automatically by Jules for task [18243924397230827278](https://jules.google.com/task/18243924397230827278) started by @neerazz*