### PR TITLE
[codex] Add sliding window interview drill

### DIFF
--- a/interviewDrills/LongestSubstringWithoutRepeating.java
+++ b/interviewDrills/LongestSubstringWithoutRepeating.java
@@ -1,0 +1,67 @@
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * MAANG screen drill: Longest Substring Without Repeating Characters.
+ *
+ * Interview signal:
+ * - Can you maintain a valid sliding window without re-scanning characters?
+ * - Can you move the left pointer only forward when a duplicate appears?
+ *
+ * Problem:
+ * Return the length of the longest substring that contains no repeated
+ * characters.
+ *
+ * Approach:
+ * 1. Track the last index where each character appeared.
+ * 2. Keep a sliding window [left, right] with no duplicates.
+ * 3. When a character repeats inside the current window, move left to one
+ *    position after its previous occurrence.
+ * 4. Update the best window length after each character.
+ *
+ * Complexity:
+ * - Time: O(n), where n is s.length().
+ * - Space: O(m), where m is the number of distinct characters in the window.
+ */
+public class LongestSubstringWithoutRepeating {
+
+    public static int lengthOfLongestSubstring(String s) {
+        if (s == null || s.isEmpty()) {
+            return 0;
+        }
+
+        Map<Character, Integer> lastSeen = new HashMap<>();
+        int left = 0;
+        int best = 0;
+
+        for (int right = 0; right < s.length(); right++) {
+            char current = s.charAt(right);
+            Integer previousIndex = lastSeen.get(current);
+
+            if (previousIndex != null && previousIndex >= left) {
+                left = previousIndex + 1;
+            }
+
+            lastSeen.put(current, right);
+            best = Math.max(best, right - left + 1);
+        }
+
+        return best;
+    }
+
+    public static void main(String[] args) {
+        expect(3, lengthOfLongestSubstring("abcabcbb"), "moves through repeated pattern");
+        expect(1, lengthOfLongestSubstring("bbbbb"), "all characters repeat");
+        expect(3, lengthOfLongestSubstring("pwwkew"), "does not count subsequences");
+        expect(2, lengthOfLongestSubstring("abba"), "left pointer never moves backward");
+        expect(0, lengthOfLongestSubstring(""), "empty string");
+
+        System.out.println("All LongestSubstringWithoutRepeating drill checks passed.");
+    }
+
+    private static void expect(int expected, int actual, String label) {
+        if (expected != actual) {
+            throw new AssertionError(label + " expected " + expected + " but got " + actual);
+        }
+    }
+}

--- a/interviewDrills/README.md
+++ b/interviewDrills/README.md
@@ -21,6 +21,7 @@ Short, runnable drills for candidates who want more than a problem list. Each dr
 | Drill | Pattern | Why it matters |
 | --- | --- | --- |
 | [Top K Frequent Words]({% link interviewDrills/top-k-frequent-words.md %}) | Hash map + bounded heap | Common screening shape for search, ranking, logs, and product analytics questions. |
+| [Longest Substring Without Repeating Characters]({% link interviewDrills/longest-substring-without-repeating.md %}) | Sliding window + last-seen index map | Core string/window question that exposes pointer movement and off-by-one mistakes fast. |
 
 ## Practice rule
 

--- a/interviewDrills/longest-substring-without-repeating.md
+++ b/interviewDrills/longest-substring-without-repeating.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: "Longest Substring Without Repeating Characters"
+parent: "Interview Drills"
+nav_order: 2
+---
+
+# Longest Substring Without Repeating Characters
+
+**Pattern:** sliding window + last-seen index map  
+**Target time:** 20 minutes coding, 5 minutes explanation, 5 minutes tests
+
+## Problem
+
+Given a string `s`, return the length of the longest substring that contains no repeated characters.
+
+Example:
+
+```text
+s = "abcabcbb"
+answer = 3  // "abc"
+```
+
+## What to say in the interview
+
+Start with the invariant:
+
+- The current window from `left` to `right` must contain no duplicate characters.
+- A map from character to last-seen index tells us whether the new character repeats inside the current window.
+- If it does, move `left` to one position after the previous occurrence.
+- Never move `left` backward. That is the bug that breaks inputs like `"abba"`.
+
+## Common trap
+
+Do not remove characters one-by-one unless the interviewer asks for the set-based version. The last-seen index map gives a cleaner `O(n)` solution because each duplicate tells you exactly where the next valid window starts.
+
+## Edge cases to test
+
+- empty string returns `0`;
+- every character repeats, like `"bbbbb"`;
+- repeated character appears before the current window, like `"abba"`;
+- answer is a substring, not a subsequence, like `"pwwkew"` → `"wke"`.
+
+## Runnable solution
+
+Code: [`LongestSubstringWithoutRepeating.java`]({% link interviewDrills/LongestSubstringWithoutRepeating.java %})
+
+Run it locally:
+
+```bash
+javac interviewDrills/LongestSubstringWithoutRepeating.java
+java -cp interviewDrills LongestSubstringWithoutRepeating
+```
+
+Expected output:
+
+```text
+All LongestSubstringWithoutRepeating drill checks passed.
+```


### PR DESCRIPTION
## What's going on

Added a second runnable interview drill so the FAANG repo has fresh, useful practice content instead of another passive problem list. This one covers the sliding-window pattern through Longest Substring Without Repeating Characters, with the interviewer signal, common trap, edge cases, and a Java solution candidates can compile locally.

## Problem

NEE-1296 asks to keep the FAANG repo alive by shipping a useful coding drill. The drills section only had one entry, so the smallest valuable ship was one more complete drill rather than a wider content refresh.

## Solution

Added `interviewDrills/LongestSubstringWithoutRepeating.java` with a last-seen-index sliding-window implementation and built-in checks. Added the companion drill page at `interviewDrills/longest-substring-without-repeating.md`, then linked it from `interviewDrills/README.md`.

Scope cut: I did not reorganize the older algorithm files or add a drill generator. One complete, runnable drill is the right unit of work for keeping the repo active without creating maintenance drag.

## Testing

- `javac interviewDrills/TopKFrequentWords.java interviewDrills/LongestSubstringWithoutRepeating.java`
- `java -cp interviewDrills TopKFrequentWords` → `All TopKFrequentWords drill checks passed.`
- `java -cp interviewDrills LongestSubstringWithoutRepeating` → `All LongestSubstringWithoutRepeating drill checks passed.`
- Docker Jekyll build with the same Ruby major as CI: `docker run --rm -v "$PWD:/srv/site" -w /srv/site -e BUNDLE_PATH=/tmp/bundle -e BUNDLE_FROZEN=true ruby:3.1 bash -lc 'bundle install >/tmp/bundle-install.log && JEKYLL_ENV=production bundle exec jekyll build >/tmp/jekyll-build.log'`
- Verified generated page and drills index contain the new drill in `_site/interviewDrills/longest-substring-without-repeating.html` and `_site/interviewDrills/README.html`.

## Notes

Rollback: revert commit `2f8f446`. Production deploy happens through the existing GitHub Pages workflow after merge to `master`; PR builds exercise the same Jekyll build path before that deploy.
