### PR TITLE
Add Daily Temperatures interview drill (monotonic stack)

### DIFF
--- a/interviewDrills/DailyTemperatures.java
+++ b/interviewDrills/DailyTemperatures.java
@@ -1,0 +1,88 @@
+import java.util.Arrays;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * MAANG screen drill: Daily Temperatures (monotonic decreasing stack).
+ *
+ * Interview signal:
+ * - Do you recognize "next greater element" as a monotonic-stack pattern
+ *   instead of brute-force O(n^2) double loops?
+ * - Do you store indices on the stack (not values), so you can compute the
+ *   distance between the warmer day and the day waiting for it?
+ *
+ * Problem:
+ * Given an array of integer daily temperatures, return an array answer where
+ * answer[i] is the number of days you have to wait after day i to get a
+ * warmer temperature. If no future day is warmer, answer[i] = 0.
+ *
+ * Approach:
+ * 1. Walk left to right keeping a stack of indices whose answer is unknown.
+ * 2. While the current temperature is strictly greater than the temperature
+ *    at the top index, that top index has just found its warmer day -- pop
+ *    it and write the gap (currentIndex - poppedIndex) into answer.
+ * 3. Push the current index. Stack stays monotonically decreasing in
+ *    temperature, so each index is pushed and popped at most once.
+ *
+ * Complexity:
+ * - Time: O(n). Each index is pushed and popped at most once.
+ * - Space: O(n) for the stack and the output array.
+ */
+public class DailyTemperatures {
+
+    public static int[] dailyTemperatures(int[] temperatures) {
+        if (temperatures == null || temperatures.length == 0) {
+            return new int[0];
+        }
+
+        int[] answer = new int[temperatures.length];
+        Deque<Integer> waitingIndices = new ArrayDeque<>();
+
+        for (int i = 0; i < temperatures.length; i++) {
+            while (!waitingIndices.isEmpty()
+                    && temperatures[i] > temperatures[waitingIndices.peek()]) {
+                int waitingIndex = waitingIndices.pop();
+                answer[waitingIndex] = i - waitingIndex;
+            }
+            waitingIndices.push(i);
+        }
+
+        return answer;
+    }
+
+    public static void main(String[] args) {
+        expect(new int[] {1, 1, 4, 2, 1, 1, 0, 0},
+                dailyTemperatures(new int[] {73, 74, 75, 71, 69, 72, 76, 73}),
+                "classic mixed warming and cooling stretch");
+
+        expect(new int[] {1, 1, 1, 0},
+                dailyTemperatures(new int[] {30, 40, 50, 60}),
+                "strictly increasing -- every day waits one");
+
+        expect(new int[] {0, 0, 0, 0},
+                dailyTemperatures(new int[] {60, 50, 40, 30}),
+                "strictly decreasing -- no warmer day ever");
+
+        expect(new int[] {0, 0, 0, 0},
+                dailyTemperatures(new int[] {50, 50, 50, 50}),
+                "ties do not count -- strictly greater required");
+
+        expect(new int[] {0},
+                dailyTemperatures(new int[] {99}),
+                "single day has no future");
+
+        expect(new int[0],
+                dailyTemperatures(new int[0]),
+                "empty input returns empty answer");
+
+        System.out.println("All DailyTemperatures drill checks passed.");
+    }
+
+    private static void expect(int[] expected, int[] actual, String label) {
+        if (!Arrays.equals(expected, actual)) {
+            throw new AssertionError(label
+                    + " expected " + Arrays.toString(expected)
+                    + " but got " + Arrays.toString(actual));
+        }
+    }
+}

--- a/interviewDrills/README.md
+++ b/interviewDrills/README.md
@@ -21,6 +21,7 @@ Short, runnable drills for candidates who want more than a problem list. Each dr
 | Drill | Pattern | Why it matters |
 | --- | --- | --- |
 | [Top K Frequent Words]({% link interviewDrills/top-k-frequent-words.md %}) | Hash map + bounded heap | Common screening shape for search, ranking, logs, and product analytics questions. |
+| [Daily Temperatures]({% link interviewDrills/daily-temperatures.md %}) | Monotonic decreasing stack of indices | Standard "next greater element" framing — separates candidates who reach for `O(n^2)` from those who recognize the stack pattern. |
 
 ## Practice rule
 

--- a/interviewDrills/daily-temperatures.md
+++ b/interviewDrills/daily-temperatures.md
@@ -1,0 +1,83 @@
+---
+layout: default
+title: "Daily Temperatures"
+parent: "Interview Drills"
+nav_order: 3
+---
+
+# Daily Temperatures
+
+**Pattern:** monotonic decreasing stack of indices (next greater element)  
+**Target time:** 20 minutes coding, 5 minutes explanation, 5 minutes tests
+
+## Problem
+
+Given an integer array `temperatures` where `temperatures[i]` is the
+temperature on day `i`, return an array `answer` such that `answer[i]` is
+the number of days you must wait after day `i` to get a warmer
+temperature. If no future day is warmer, `answer[i] = 0`.
+
+Example:
+
+```text
+temperatures = [73, 74, 75, 71, 69, 72, 76, 73]
+answer       = [ 1,  1,  4,  2,  1,  1,  0,  0]
+```
+
+## What to say in the interview
+
+Lead with the trade-off, not the code:
+
+- Brute force is two nested loops, O(n^2). For each day, scan forward for
+  the first warmer day. This will get you to a working answer but it tells
+  the interviewer you missed the pattern.
+- The pattern is **next greater element**: every position is waiting for
+  the first strictly greater value to its right. That is a textbook
+  monotonic-stack problem and runs in O(n).
+- Push **indices**, not temperatures. The answer is a *distance*
+  (`currentIndex - waitingIndex`), so you need the position, not the
+  value. Look up the temperature through `temperatures[stack.peek()]`.
+
+The invariant: the stack always holds indices whose warmer day has not
+been found yet, with their temperatures strictly decreasing from bottom
+to top. When today's temperature is strictly greater than the
+temperature at the top, today is *the* warmer day for that index and the
+answer is fixed forever.
+
+## Common trap
+
+- Storing temperatures on the stack instead of indices. You then cannot
+  compute the gap and end up smuggling parallel arrays around.
+- Using `>=` instead of `>`. Equal temperatures must stay on the stack:
+  the question asks for *strictly* warmer, so a tie does not resolve
+  anything.
+- Reaching for a heap. A heap is `O(n log n)` and overkill — the
+  monotonic-stack property gives you each index pushed and popped at
+  most once, so the total work is `O(n)`.
+
+## Edge cases to test
+
+- empty input returns an empty array;
+- single day, like `[99]`, returns `[0]`;
+- strictly increasing input, like `[30, 40, 50, 60]`, returns
+  `[1, 1, 1, 0]`;
+- strictly decreasing input, like `[60, 50, 40, 30]`, returns all zeros;
+- repeated values, like `[50, 50, 50, 50]`, returns all zeros because
+  ties do not count.
+
+## Runnable solution
+
+Code: [`DailyTemperatures.java`]({% link interviewDrills/DailyTemperatures.java %})
+
+Run it locally:
+
+```bash
+javac interviewDrills/DailyTemperatures.java
+java -cp interviewDrills DailyTemperatures
+```
+
+Expected output:
+
+```text
+All DailyTemperatures drill checks passed.
+```


### PR DESCRIPTION
## Summary

- Third runnable drill in `interviewDrills/`: **Daily Temperatures** — the canonical *next greater element* / monotonic-decreasing stack pattern.
- `DailyTemperatures.java` is `O(n)` with a `main()` self-test that covers increasing, decreasing, mixed, repeated-tie, single-day, and empty inputs.
- `daily-temperatures.md` walks through the pattern recognition, what to say in the interview, common traps (indices vs. values, `>=` vs. `>`, reaching for a heap), and edge cases.
- `interviewDrills/README.md` links the new drill into the index table.

## Why this drill

The two existing drills cover **sliding window** (longest substring) and **bounded heap** (top-k frequent). Monotonic stack is the next high-signal pattern that consistently shows up in MAANG screens (LC 739, 496, 503, 84) and is orthogonal to both — so candidates who do this drill add a real new tool, not a rehash.

## Verification

```
javac interviewDrills/DailyTemperatures.java
java -cp interviewDrills DailyTemperatures
-> All DailyTemperatures drill checks passed.
```

Jekyll build will run as the PR check (`Deploy Jekyll site to Pages` workflow, build job). Will merge after that goes green; the deploy job runs only on push to `master`.

## Rollback

Revert the merge commit. No data, no infra, just a static-site addition.