### PR TITLE
Add LRU Cache interview drill (HashMap + doubly linked list)

### DIFF
--- a/interviewDrills/LRUCache.java
+++ b/interviewDrills/LRUCache.java
@@ -1,0 +1,185 @@
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * MAANG screen drill: LRU Cache (HashMap + doubly linked list).
+ *
+ * Interview signal:
+ * - Do you reach for the right composite structure -- a hash map for O(1)
+ *   lookup paired with a doubly linked list for O(1) eviction and reorder --
+ *   instead of a TreeMap or a single LinkedHashMap one-liner?
+ * - Do you handle the head/tail pointers correctly when the list is empty,
+ *   has one node, or has the same node moved to the front twice in a row?
+ *
+ * Problem:
+ * Design a data structure that supports get(key) and put(key, value) in O(1)
+ * average time. The cache has a fixed capacity; when it overflows, evict the
+ * least recently used entry. Both get and put count as a "use".
+ *
+ * Approach:
+ * 1. HashMap<Integer, Node> gives O(1) lookup from key to its list node.
+ * 2. A doubly linked list with sentinel head/tail nodes orders entries from
+ *    most recently used (right after head) to least recently used (right
+ *    before tail). Sentinels remove every null check around list edits.
+ * 3. get  -> if present, unlink the node and reinsert it after head.
+ *    put  -> if present, update value and move to front; else insert a new
+ *            node after head and, if size > capacity, drop the node before
+ *            tail and remove its key from the map.
+ *
+ * Complexity:
+ * - Time: O(1) average for both operations -- map lookup plus constant list
+ *   pointer rewires.
+ * - Space: O(capacity) for the map and the list nodes.
+ */
+public class LRUCache {
+
+    private static final class Node {
+        final int key;
+        int value;
+        Node prev;
+        Node next;
+
+        Node(int key, int value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private final int capacity;
+    private final Map<Integer, Node> index;
+    private final Node head;
+    private final Node tail;
+
+    public LRUCache(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("capacity must be positive");
+        }
+        this.capacity = capacity;
+        this.index = new HashMap<>(capacity);
+        this.head = new Node(0, 0);
+        this.tail = new Node(0, 0);
+        this.head.next = this.tail;
+        this.tail.prev = this.head;
+    }
+
+    public int get(int key) {
+        Node node = index.get(key);
+        if (node == null) {
+            return -1;
+        }
+        moveToFront(node);
+        return node.value;
+    }
+
+    public void put(int key, int value) {
+        Node existing = index.get(key);
+        if (existing != null) {
+            existing.value = value;
+            moveToFront(existing);
+            return;
+        }
+
+        Node node = new Node(key, value);
+        index.put(key, node);
+        insertAfterHead(node);
+
+        if (index.size() > capacity) {
+            Node evict = tail.prev;
+            unlink(evict);
+            index.remove(evict.key);
+        }
+    }
+
+    public int size() {
+        return index.size();
+    }
+
+    private void moveToFront(Node node) {
+        unlink(node);
+        insertAfterHead(node);
+    }
+
+    private void insertAfterHead(Node node) {
+        node.prev = head;
+        node.next = head.next;
+        head.next.prev = node;
+        head.next = node;
+    }
+
+    private void unlink(Node node) {
+        node.prev.next = node.next;
+        node.next.prev = node.prev;
+        node.prev = null;
+        node.next = null;
+    }
+
+    public static void main(String[] args) {
+        runLeetcodeExample();
+        runUpdateRefreshesRecency();
+        runRepeatedGetIsIdempotent();
+        runSingleSlotEvictsImmediately();
+        runRejectsNonPositiveCapacity();
+
+        System.out.println("All LRUCache drill checks passed.");
+    }
+
+    private static void runLeetcodeExample() {
+        LRUCache cache = new LRUCache(2);
+        cache.put(1, 1);
+        cache.put(2, 2);
+        expect(1, cache.get(1), "get(1) returns 1");
+        cache.put(3, 3);
+        expect(-1, cache.get(2), "key 2 evicted by put(3,3)");
+        cache.put(4, 4);
+        expect(-1, cache.get(1), "key 1 evicted by put(4,4)");
+        expect(3, cache.get(3), "key 3 still present");
+        expect(4, cache.get(4), "key 4 still present");
+    }
+
+    private static void runUpdateRefreshesRecency() {
+        LRUCache cache = new LRUCache(2);
+        cache.put(1, 1);
+        cache.put(2, 2);
+        cache.put(1, 11);
+        cache.put(3, 3);
+        expect(-1, cache.get(2), "updating key 1 made key 2 the LRU");
+        expect(11, cache.get(1), "key 1 retains the updated value");
+    }
+
+    private static void runRepeatedGetIsIdempotent() {
+        LRUCache cache = new LRUCache(2);
+        cache.put(1, 1);
+        cache.put(2, 2);
+        cache.get(1);
+        cache.get(1);
+        cache.get(1);
+        cache.put(3, 3);
+        expect(-1, cache.get(2), "key 2 stays the LRU even after repeated get(1)");
+        expect(1, cache.get(1), "key 1 still present");
+    }
+
+    private static void runSingleSlotEvictsImmediately() {
+        LRUCache cache = new LRUCache(1);
+        cache.put(1, 1);
+        cache.put(2, 2);
+        expect(-1, cache.get(1), "single-slot cache evicts on every new key");
+        expect(2, cache.get(2), "newest key remains");
+    }
+
+    private static void runRejectsNonPositiveCapacity() {
+        try {
+            new LRUCache(0);
+        } catch (IllegalArgumentException expected) {
+            return;
+        }
+        throw new AssertionError("capacity 0 should throw IllegalArgumentException");
+    }
+
+    private static void expect(int expected, int actual, String label) {
+        if (expected != actual) {
+            throw new AssertionError(label
+                    + " expected " + expected
+                    + " but got " + actual);
+        }
+    }
+}

--- a/interviewDrills/README.md
+++ b/interviewDrills/README.md
@@ -22,6 +22,7 @@ Short, runnable drills for candidates who want more than a problem list. Each dr
 | --- | --- | --- |
 | [Top K Frequent Words]({% link interviewDrills/top-k-frequent-words.md %}) | Hash map + bounded heap | Common screening shape for search, ranking, logs, and product analytics questions. |
 | [Daily Temperatures]({% link interviewDrills/daily-temperatures.md %}) | Monotonic decreasing stack of indices | Standard "next greater element" framing — separates candidates who reach for `O(n^2)` from those who recognize the stack pattern. |
+| [LRU Cache]({% link interviewDrills/lru-cache.md %}) | Hash map + doubly linked list with sentinels | The canonical "design a data structure" warmup — checks whether you compose two primitives for O(1) ops instead of grabbing a `LinkedHashMap` one-liner. |
 
 ## Practice rule
 

--- a/interviewDrills/lru-cache.md
+++ b/interviewDrills/lru-cache.md
@@ -1,0 +1,93 @@
+---
+layout: default
+title: "LRU Cache"
+parent: "Interview Drills"
+nav_order: 4
+---
+
+# LRU Cache
+
+**Pattern:** hash map for O(1) lookup + doubly linked list for O(1) recency updates
+**Target time:** 25 minutes coding, 5 minutes explanation, 5 minutes tests
+
+## Problem
+
+Design a data structure that supports two operations in O(1) average time:
+
+- `get(key)` returns the value if the key is present, otherwise `-1`.
+- `put(key, value)` inserts or updates the entry. When inserting causes the
+  cache to exceed its fixed `capacity`, evict the least recently used entry.
+
+Both `get` and `put` count as a "use" — they refresh the entry's recency.
+
+## What to say in the interview
+
+Lead with the structure, not the code. The interviewer is mostly checking
+whether you reach for the right composite data structure.
+
+- Why not a `TreeMap` keyed by last-access time? Updating a key on every
+  access is `O(log n)`. The bar here is `O(1)`.
+- Why not a single `LinkedHashMap` with `accessOrder=true`? It works, but
+  most interviewers want to see that you can build the structure from
+  primitives. Mention the one-liner so the interviewer knows you know it,
+  then build it manually.
+- The right answer is a **HashMap from key to list node** plus a
+  **doubly linked list** ordered most-recently-used to least-recently-used.
+  The map gives O(1) lookup. The list gives O(1) "move to front" and O(1)
+  "drop the tail" because each node already knows its neighbors.
+
+The invariant: the head of the list is the most recently used entry, the
+tail is the least recently used. Every `get` and `put` either inserts a
+node right after the head sentinel or unlinks it from its current spot
+and reinserts it there. Every overflow drops the node right before the
+tail sentinel and removes its key from the map.
+
+Use **sentinel head and tail nodes**. They look like extra code, but they
+remove every null check around list edits — `head.next` and `tail.prev`
+are always valid. Without sentinels, half your bugs come from special
+cases at list boundaries.
+
+## Common traps
+
+- **Forgetting to remove the evicted key from the map.** The list shrinks
+  but the map keeps growing — the cache silently exceeds capacity and
+  every "miss" still hits a stale node. Always do both: unlink from the
+  list *and* remove from the map.
+- **Updating a value but not refreshing recency.** A `put` on an existing
+  key is also a "use". If you skip `moveToFront`, the entry can be
+  evicted right after a fresh write — which violates LRU semantics and
+  is the exact failure most graders test for.
+- **Storing only the value in the map.** You then cannot find the list
+  node from the key, so `get` becomes `O(n)` to locate it. Map keys must
+  point at nodes, not values.
+- **Single-node list edge case.** Moving the only real node to the front
+  must still leave the list in a valid state. Sentinels make this work
+  for free; without them, you have to special-case it.
+
+## Edge cases to test
+
+- standard LeetCode 146 trace: `put(1,1), put(2,2), get(1)=1, put(3,3)
+  evicts 2, put(4,4) evicts 1, get(3)=3, get(4)=4`;
+- `put` on an existing key updates the value *and* refreshes recency, so
+  the other key becomes the LRU;
+- repeated `get` on the same key does not change which entry is the LRU;
+- `capacity = 1` evicts on every new key;
+- non-positive capacity should be rejected at construction time — most
+  graders do not test this, but interviewers respect explicit bounds.
+
+## Runnable solution
+
+Code: [`LRUCache.java`]({% link interviewDrills/LRUCache.java %})
+
+Run it locally:
+
+```bash
+javac interviewDrills/LRUCache.java
+java -cp interviewDrills LRUCache
+```
+
+Expected output:
+
+```text
+All LRUCache drill checks passed.
+```


### PR DESCRIPTION
## Summary
- Adds the canonical FAANG design-a-data-structure drill: LRU Cache implemented with `HashMap<Integer, Node>` + doubly linked list with sentinel head/tail.
- Drill follows the established `interviewDrills/` format: runnable Java with self-checking `main`, plus a markdown explainer with the interview signal, the three traps that fail this question, and edge cases.
- Indexed in `interviewDrills/README.md` so it surfaces from the Jekyll nav.

## Why this drill
- Composite-structure design — the bar test for whether a candidate composes two primitives for `O(1)` ops, or falls back to `LinkedHashMap` / `TreeMap`.
- Distinct from the existing drills (heap, monotonic stack), so it expands the pattern coverage rather than duplicating.

## Verification
- `javac interviewDrills/LRUCache.java && java -cp interviewDrills LRUCache` -> `All LRUCache drill checks passed.`
- Five scenarios covered by `main`: LeetCode 146 trace, `put`-on-existing-key refreshes recency, repeated `get` is idempotent, single-slot eviction, non-positive capacity rejected.
- Jekyll build will run on this PR via `.github/workflows/gh-pages.yml`; merging to `master` triggers the deploy job.

## Rollback
- Single commit, three new/modified files. `git revert` the merge to undo cleanly - no schema or workflow changes.